### PR TITLE
use getPath if getfilename not available.

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -66,10 +66,16 @@ def doDownload():
 def getDbId():
     infolabel = xbmc.getInfoLabel('ListItem.Label')
     truelabel = sys.listitem.getLabel()
+
+    try:
+        path = sys.listitem.getfilename()
+    except AttributeError:
+        path = sys.listitem.getPath()
+
     if infolabel == truelabel and xbmc.getInfoLabel('ListItem.DBID'):
         dbid = xbmc.getInfoLabel('ListItem.DBID')
-    elif 'elementum' in sys.listitem.getfilename():
-        dbid = sys.listitem.getfilename().split('?')[0].rstrip('/').split('/')[-1]
+    elif 'elementum' in path:
+        dbid = path.split('?')[0].rstrip('/').split('/')[-1]
     else:
         if xbmc.getInfoLabel('ListItem.Episode') and xbmc.getInfoLabel('ListItem.TVSHowTitle') and xbmc.getInfoLabel('ListItem.Season'):
             season = int(xbmc.getInfoLabel('ListItem.Season'))


### PR DESCRIPTION
https://codedocs.xyz/AlwinEsch/kodi/python_v19.html

>xbmcgui.ListItem().getfilename() function was removed completely.

but we can use [getPath()](https://codedocs.xyz/MartijnKaijser/xbmc/group__python__xbmcgui__listitem.html#ga53d5d2b698b1e41dee0014a79413de68)

tested on kodi 17 and 19

should fix #8 

original error:
```
2021-03-06 12:52:13.233 T:901129    INFO <general>: initializing python engine.
2021-03-06 12:52:13.733 T:901129   ERROR <general>: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                                    - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                                   Error Type: <class 'AttributeError'>
                                                   Error Contents: 'xbmcgui.ListItem' object has no attribute 'getfilename'
                                                   Traceback (most recent call last):
                                                     File "/home/antix/.kodi/addons/context.elementum/context_play.py", line 8, in <module>
                                                       doPlay()
                                                     File "/home/antix/.kodi/addons/context.elementum/plugin.py", line 41, in doPlay
                                                       dbid = getDbId()
                                                     File "/home/antix/.kodi/addons/context.elementum/plugin.py", line 71, in getDbId
                                                       elif 'elementum' in sys.listitem.getfilename():
                                                   AttributeError: 'xbmcgui.ListItem' object has no attribute 'getfilename'
                                                   -->End of Python script error report<--
                                                   
2021-03-06 12:52:13.778 T:901129    INFO <general>: Python interpreter stopped
```