### PR TITLE
Use elementum path for play/download

### DIFF
--- a/context_info.py
+++ b/context_info.py
@@ -61,6 +61,7 @@ info_labels = [
     "ListItem.Progress",
     "ListItem.Status",
     "ListItem.Count",
+    "ListItem.PercentPlayed",
 ]
 
 if __name__ == '__main__':
@@ -81,7 +82,8 @@ if __name__ == '__main__':
     properties = {
         'resume_time': item.getProperty('ResumeTime'),
         'start_offset': item.getProperty('StartOffset'),
-        'start_percent': item.getProperty('StartPercent')
+        'start_percent': item.getProperty('StartPercent'),
+        'total_time': item.getProperty('TotalTime')
     }
     log.info("Properties: %s;" % properties)
 

--- a/plugin.py
+++ b/plugin.py
@@ -140,11 +140,24 @@ def doDownload():
     dbid = getDbId()
     mediatype = getMediaType()
 
+    use_elementum_path = False
+    if not dbid.isdigit():
+        try:
+            path = sys.listitem.getfilename()
+        except AttributeError:
+            path = sys.listitem.getPath()
+        if path.startswith("plugin://plugin.video.elementum"):
+            use_elementum_path = True
+
     xbmcgui.Dialog().notification(ADDON.getLocalizedString(32013), sys.listitem.getLabel(), xbmcgui.NOTIFICATION_INFO, 3000)
 
-    log.info("Downloading for: DBID=%s, MediaType=%s" % (dbid, mediatype))
+    if use_elementum_path:
+        log.info("Downloading elementum item: path=%s, MediaType=%s" % (path, mediatype))
+        url = re.sub(r'/(play|links)(/?[^/]*)$', r'/download\g<2>', path, count=1)
+    else:
+        log.info("Downloading library item: DBID=%s, MediaType=%s" % (dbid, mediatype))
+        url = "plugin://plugin.video.elementum/context/media/%s/%s/download" % (mediatype, dbid)
 
-    url = "plugin://plugin.video.elementum/context/media/%s/%s/download" % (mediatype, dbid)
     log.info("Starting Elementum with: %s" % url)
     xbmc.Player().play(url)
 

--- a/plugin.py
+++ b/plugin.py
@@ -114,11 +114,24 @@ def doPlay():
     dbid = getDbId()
     mediatype = getMediaType()
 
+    use_elementum_path = False
+    if not dbid.isdigit():
+        try:
+            path = sys.listitem.getfilename()
+        except AttributeError:
+            path = sys.listitem.getPath()
+        if path.startswith("plugin://plugin.video.elementum"):
+            use_elementum_path = True
+
     xbmcgui.Dialog().notification(ADDON.getLocalizedString(32009), sys.listitem.getLabel(), xbmcgui.NOTIFICATION_INFO, 3000)
 
-    log.info("Playing for: DBID=%s, MediaType=%s" % (dbid, mediatype))
+    if use_elementum_path:
+        log.info("Playing elementum item: path=%s, MediaType=%s" % (path, mediatype))
+        url = path
+    else:
+        log.info("Playing library item: DBID=%s, MediaType=%s" % (dbid, mediatype))
+        url = "plugin://plugin.video.elementum/context/media/%s/%s/play" % (mediatype, dbid)
 
-    url = "plugin://plugin.video.elementum/context/media/%s/%s/play" % (mediatype, dbid)
     log.info("Starting Elementum with: %s" % url)
     xbmc.Player().play(url)
 


### PR DESCRIPTION
instead of search by name.

so i guess search by name now will be used only for non library or non elementum items - e.g. other addons items. 