### PR TITLE
Fix Kodi methods deprecations as of 04.2025

### DIFF
--- a/context_info.py
+++ b/context_info.py
@@ -64,6 +64,9 @@ info_labels = [
     "ListItem.PercentPlayed",
 ]
 
+build_version = xbmc.getInfoLabel("System.BuildVersion")
+kodi_version = int(build_version.split()[0][:2])
+
 if __name__ == '__main__':
     item = sys.listitem  # xbmcgui.ListItem()
     try:
@@ -75,15 +78,15 @@ if __name__ == '__main__':
     dbid = xbmc.getInfoLabel('ListItem.DBID')
     mediatype = xbmc.getInfoLabel('ListItem.DBTYPE')
     try:
-        tmdbID = item.getUniqueID('tmdb')
+        tmdbID = item.getUniqueID('tmdb') if kodi_version < 20 else item.getVideoInfoTag().getUniqueID('tmdb')
     except AttributeError:
         tmdbID = "not supported"
 
     properties = {
-        'resume_time': item.getProperty('ResumeTime'),
+        'resume_time': item.getProperty('ResumeTime') if kodi_version < 20 else item.getVideoInfoTag().getResumeTime(),
+        'total_time': item.getProperty('TotalTime') if kodi_version < 20 else item.getVideoInfoTag().getResumeTimeTotal(),
         'start_offset': item.getProperty('StartOffset'),
         'start_percent': item.getProperty('StartPercent'),
-        'total_time': item.getProperty('TotalTime')
     }
     log.info("Properties: %s;" % properties)
 

--- a/plugin.py
+++ b/plugin.py
@@ -30,6 +30,9 @@ from elementum.logger import log
 ADDON = xbmcaddon.Addon()
 api_key = ""
 
+build_version = xbmc.getInfoLabel("System.BuildVersion")
+kodi_version = int(build_version.split()[0][:2])
+
 
 def doAssign():
     mediatype = getMediaType()
@@ -42,7 +45,7 @@ def doAssign():
     use_elementum_path = False
 
     try:
-        tmdbID = sys.listitem.getUniqueID('tmdb')
+        tmdbID = sys.listitem.getUniqueID('tmdb') if kodi_version < 20 else sys.listitem.getVideoInfoTag().getUniqueID('tmdb')
     except AttributeError:
         tmdbID = ""
 
@@ -175,7 +178,7 @@ def doPlayDownload(action, is_custom=False):
 def doLibraryAction(action):
     dbid = getDbId()
     try:
-        tmdbID = sys.listitem.getUniqueID('tmdb')
+        tmdbID = sys.listitem.getUniqueID('tmdb') if kodi_version < 20 else sys.listitem.getVideoInfoTag().getUniqueID('tmdb')
     except AttributeError:
         tmdbID = ""
     mediatype = getMediaType()
@@ -208,7 +211,7 @@ def doTraktAction(action):
     if not dbid.isdigit():
         showtmdbid = xbmc.getInfoLabel('ListItem.Property(ShowTMDBId)')
         try:
-            tmdbID = sys.listitem.getUniqueID('tmdb')
+            tmdbID = sys.listitem.getUniqueID('tmdb') if kodi_version < 20 else sys.listitem.getVideoInfoTag().getUniqueID('tmdb')
         except AttributeError:
             tmdbID = ""
         if tmdbID == "" or ((mediatype == 'season' or mediatype == 'episode') and showtmdbid == ""):


### PR DESCRIPTION
getUniqueID()
old https://xbmc.github.io/docs.kodi.tv/master/kodi-base/d8/d29/group__python__xbmcgui__listitem.html#ga6a2fd42302d170b4f34202e93fc82da0
new https://xbmc.github.io/docs.kodi.tv/master/kodi-base/d9/dc2/group__python___info_tag_video.html#ga166ef1190b5ab5ccf0c69aa1116b4c22

getProperty() ResumeTime and TotalTime
old https://xbmc.github.io/docs.kodi.tv/master/kodi-base/d8/d29/group__python__xbmcgui__listitem.html#gaf3890e39353d2e8f46928653667e7d81
new
getResumeTime() https://xbmc.github.io/docs.kodi.tv/master/kodi-base/d9/dc2/group__python___info_tag_video.html#gac4af7bb610e112d28f5df8acf639d1f0
getResumeTimeTotal() https://xbmc.github.io/docs.kodi.tv/master/kodi-base/d9/dc2/group__python___info_tag_video.html#ga243d1bd876046e08a2863f45c4551777
